### PR TITLE
Sequential elaboration

### DIFF
--- a/common/s-fretas.ads
+++ b/common/s-fretas.ads
@@ -57,12 +57,24 @@ package System.FreeRTOS.Tasks is
      Convention => C,
      External_Name => "vTaskResume";
 
+   procedure Resume_All_Tasks
+   with
+     Import,
+     Convention => C,
+     External_Name => "xTaskResumeAll";
+
    procedure Suspend (T : Task_Handle)
    with
      Import,
      Convention => C,
      External_Name => "vTaskSuspend";
    --  null T means "current task".
+
+   procedure Suspend_All_Tasks
+   with
+     Import,
+     Convention => C,
+     External_Name => "vTaskSuspendAll";
 
    procedure Disable_Interrupts
    with

--- a/common/s-tarest.adb
+++ b/common/s-tarest.adb
@@ -147,12 +147,50 @@ package body System.Tasking.Restricted.Stages is
       Elaborated.all := Created_Task.Common.Thread /= null;
    end Create_Restricted_Task;
 
+   procedure Create_Restricted_Task_Sequential
+     (Priority             : Integer;
+      Stack_Address        : System.Address;
+      Size                 : System.Parameters.Size_Type;
+      Secondary_Stack_Size : System.Parameters.Size_Type;
+      Task_Info            : System.Task_Info.Task_Info_Type;
+      CPU                  : Integer;
+      State                : Task_Procedure_Access;
+      Discriminants        : System.Address;
+      Elaborated           : Access_Boolean;
+      Task_Image           : String;
+      Created_Task         : Task_Id)
+   is
+      --  Create_Restricted_Task requires a Chain parameter; however,
+      --  in this RTS it's ignored, because all tasks are activated as
+      --  they are elaborated (i.e., concurrently).
+      Dummy_Activation_Chain : Activation_Chain;
+   begin
+      Create_Restricted_Task
+        (Priority             => Priority,
+         Stack_Address        => Stack_Address,
+         Size                 => Size,
+         Secondary_Stack_Size => Secondary_Stack_Size,
+         Task_Info            => Task_Info,
+         CPU                  => CPU,
+         State                => State,
+         Discriminants        => Discriminants,
+         Elaborated           => Elaborated,
+         Chain                => Dummy_Activation_Chain,  -- <<<
+         Task_Image           => Task_Image,
+         Created_Task         => Created_Task);
+   end Create_Restricted_Task_Sequential;
+
    procedure Activate_Restricted_Tasks
      (Chain_Access : Activation_Chain_Access) is
       pragma Unreferenced (Chain_Access);
    begin
       null;
    end Activate_Restricted_Tasks;
+
+   procedure Activate_All_Tasks_Sequential is
+   begin
+      null;
+   end Activate_All_Tasks_Sequential;
 
    procedure Complete_Restricted_Activation is
    begin

--- a/common/s-tarest.adb
+++ b/common/s-tarest.adb
@@ -45,6 +45,8 @@ with System.Memory;
 
 package body System.Tasking.Restricted.Stages is
 
+   Sequential_Elaboration_Started : Boolean := False;
+
    procedure Wrapper (Arg1 : System.Address) with Convention => C;
    --  This is the procedure passed to
    --  FreeRTOS.Tasks.Create_Task. Arg1 is the address of its
@@ -165,6 +167,17 @@ package body System.Tasking.Restricted.Stages is
       --  they are elaborated (i.e., concurrently).
       Dummy_Activation_Chain : Activation_Chain;
    begin
+
+      --  If we're called at all, it's because sequential activation
+      --  has been requested. If this is the first call, suspend
+      --  tasking (awaiting a call to Activate_All_Tasks_Sequential).
+      pragma Assert (Partition_Elaboration_Policy = 'S',
+                     "Partition_Elaboration_Policy not sequential");
+      if not Sequential_Elaboration_Started then
+         Sequential_Elaboration_Started := True;
+         FreeRTOS.Tasks.Suspend_All_Tasks;
+      end if;
+
       Create_Restricted_Task
         (Priority             => Priority,
          Stack_Address        => Stack_Address,
@@ -184,12 +197,19 @@ package body System.Tasking.Restricted.Stages is
      (Chain_Access : Activation_Chain_Access) is
       pragma Unreferenced (Chain_Access);
    begin
+      --  This can get called even with sequential elaboration,
+      --  because if the RTS was compiled with concurrent activation
+      --  (almost certainly the case) any tasks in the RTS (e.g. for
+      --  Timing_Events) will call here at the end of package
+      --  elaboration.
       null;
    end Activate_Restricted_Tasks;
 
    procedure Activate_All_Tasks_Sequential is
    begin
-      null;
+      pragma Assert (Partition_Elaboration_Policy = 'S',
+                     "Partition_Elaboration_Policy not sequential");
+      FreeRTOS.Tasks.Resume_All_Tasks;
    end Activate_All_Tasks_Sequential;
 
    procedure Complete_Restricted_Activation is

--- a/stm32f4/adainclude/s-interr.adb
+++ b/stm32f4/adainclude/s-interr.adb
@@ -129,6 +129,11 @@ package body System.Interrupts is
       end loop;
    end Install_Restricted_Handlers;
 
+   procedure Install_Restricted_Handlers_Sequential is
+   begin
+      null;
+   end Install_Restricted_Handlers_Sequential;
+
    --  Startup contains a weak definition of this symbol; so when this
    --  package is called in, during the link of user code that
    --  actually uses interrupts, this definition will be used instead.

--- a/stm32f4/adainclude/s-interr.ads
+++ b/stm32f4/adainclude/s-interr.ads
@@ -63,4 +63,13 @@ package System.Interrupts is
    --  are only library-level protected handlers that will be installed
    --  at initialization and never be replaced.
 
+   procedure Install_Restricted_Handlers_Sequential;
+   pragma Export (C, Install_Restricted_Handlers_Sequential,
+                  "__gnat_attach_all_handlers");
+   --  When the partition elaboration policy is sequential, attachment of
+   --  interrupts handlers is deferred until the end of elaboration. The
+   --  binder will call this procedure at the end of elaboration, just before
+   --  activating the tasks (if any).
+   --
+   --  Null implementation in this RTS.
 end System.Interrupts;

--- a/test-stm32f4/gnat.adc
+++ b/test-stm32f4/gnat.adc
@@ -1,0 +1,2 @@
+--  Used to demonstrate that sequential elaboration can be invoked.
+pragma Partition_Elaboration_Policy (Sequential);

--- a/test-stm32f4/testbed.gpr
+++ b/test-stm32f4/testbed.gpr
@@ -24,6 +24,7 @@ project Testbed is
    for Target use "arm-eabi";
    for Runtime ("ada") use Project'Project_Dir & "../stm32f4";
    package Builder is
+      for Global_Configuration_Pragmas use "gnat.adc";
       for Default_Switches ("ada") use
         (
          "-g",


### PR DESCRIPTION
If the configuration pragma `pragma Partition_Elaboration_Policy (Sequential);` is given, tasks start executing when program elaboration is complete (rather than as encountered during elaboration).

