### PR TITLE
Force Time'Size to 64 bits.

### DIFF
--- a/common/a-reatim.ads
+++ b/common/a-reatim.ads
@@ -155,6 +155,7 @@ private
    --  FreeRTOSConfig.h has set configTICK_RATE_HZ to 1000
 
    type Time is new Time_Base range 0.0 .. (2 ** 32 - 1) * FreeRTOS_Tick;
+   for Time'Size use 64;
    --  and configUSE_16_BIT_TICKS to 0 (so we get 32-bit clock values).
 
    Time_First : constant Time := Time'First;


### PR DESCRIPTION
Fixes issue #12.
  * common/a-reatim.ads (Time): use "for Time'Size" to force the size
      to 64 bits (52 bits used otherwise, since Time was changed to be
      >= 0.0).